### PR TITLE
Added support for pre-trained GloVe models

### DIFF
--- a/R/load.R
+++ b/R/load.R
@@ -38,6 +38,56 @@ load_fasttext <- function(filename, corpus=null, n=10000) {
 }
 
 
+#' Load similarity information from a GloVe model
+#'
+#' @param filename a filename pointing to a GloVe .txt model where first column is word
+#' @param corpus an optional corpus to use for word frequency information.
+#'               if given, should be a quanteda corpus, dfm or data frame with word and frequency as first two columns
+#'
+#' @returns a list with a nxn similarity matrix and a frequency data frame
+#' @export
+
+load_glove = function(filename, corpus=null, n=10000) {
+  # Warning and loading dependencies 
+  pb = progress::progress_bar$new(total = 5, format=":what [:bar] :eta")
+  pb$tick(tokens=list(what="Loading GloVe model"))
+  filename = path.expand(filename)
+  if (!file.exists(filename)) stop(paste0("File ", filename, " does not exist"))
+  
+  gl_model = data.table::fread(filename, data.table = F,  encoding = 'UTF-8') 
+  colnames(gl_model) = c('word',paste('dim',1:(ncol(gl_model)-1),sep = '_')) 
+  row.names(gl_model) = gl_model[,1] # first column words 
+  
+  # Convert to Matrix 
+  gl_model = gl_model[1:(n+(n*.1)),] 
+  gl_model = as.matrix(gl_model[,2:ncol(gl_model)], rownames.force = TRUE)
+  
+  pb$tick(tokens=list(what="Extracting vocabulary"))
+  words <- gl_model |> 
+    rownames() |>
+    stringr::str_subset("^[a-z]")
+  
+  if (!is.null(corpus)) {
+    pb$tick(tokens=list(what="Converting corpus"))
+    vocabulary = load_corpus(corpus) |> # Requires load_corpus function
+      dplyr::filter(word %in% words) |>
+      utils::head(n=n)
+  } else {
+    pb$tick(tokens=list(what="Estimating ranks"))
+    vocabulary = data.frame(words=words[1:n], frequency=.5^(0:(n-1)))
+  }
+  
+  pb$tick(tokens=list(what="Extracting vectors"))
+  vectors = gl_model[vocabulary$word,]
+  pb$tick(tokens=list(what="Normalizing vectors"))
+  vectors = vectors / sqrt(rowSums(vectors^2))
+  pb$terminate()
+  list(vectors=vectors, vocabulary=vocabulary)
+  
+  # end   
+}
+
+
 #' Get frequency information from a corpus
 load_corpus <- function(corpus) {
   if (methods::is(corpus, "corpus")) corpus = corpus |>


### PR DESCRIPTION
Re-used code from fastText loader, so we may want to split these up a bit more. However, when loading GloVe .txt files such as from the Stanford repo, the embeddings can be used just like those from fastText. 